### PR TITLE
SS4/PHP compatibility tweaks

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,6 @@
+---
+Name: externalurlfield
+---
+SilverStripe\Core\Injector\Injector:
+  ExternalURL:
+    class: BurnBright\ExternalURLField\ExternalURL

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,6 @@
 		"silverstripe/framework": "^4.0@dev",
 		"jakeasmith/http_build_url": "^1"
 	},
-	"extra": {
-		"installer-name": "externalurlfield"
-	},
 	"authors": [
 		{
 			"name": "Jeremy Shipman",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "burnbright/silverstripe-externalurlfield",
 	"description": "Provides SilverStripe with a DBField and FormField for handling external URLs.",
-	"type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
 	"license": "MIT",
 	"keywords": ["silverstripe", "url", "link", "form", "field"],
 	"require": {

--- a/src/ExternalURLField.php
+++ b/src/ExternalURLField.php
@@ -116,13 +116,15 @@ class ExternalURLField extends TextField
     /**
      * Rebuild url on save
      * @param string $url
+     * @param array|DataObject $data {@see Form::loadDataFrom}
+     * @return $this
      */
-    public function setValue($url)
+    public function setValue($url, $data = null)
     {
         if ($url) {
             $url = $this->rebuildURL($url);
         }
-        parent::setValue($url);
+        parent::setValue($url, $data);
     }
 
     /**


### PR DESCRIPTION
1. **Updating composer package type from 'silverstripe-module' to 'silverstripe-vendormodule'** so that the package is installed to /vendor directory rather than project root.

2. **Updating ExternalURLField::setValue method arguments**, to resolve php E_STRICT notice `declaration of methods should be compatible with parent methods in php`.

3. **Applying injection pattern** per silverstripe-framework's DBField classes, to resolve `Uncaught SilverStripe\Core\Injector\InjectorNotFoundException: ReflectionException: Class ExternalURL does not exist in /framework/src/Core/Injector/InjectionCreator.php:17`


