### PR TITLE
Allow override of default example.com placeholder

### DIFF
--- a/src/ExternalURLField.php
+++ b/src/ExternalURLField.php
@@ -97,9 +97,13 @@ class ExternalURLField extends TextField
      */
     public function getAttributes()
     {
-        $attributes = array(
-            'placeholder' => $this->config['defaultparts']['scheme'] . "://example.com" //example url
-        );
+        $parentAttributes = parent::getAttributes();
+        $attributes = array();
+
+        if (!isset($parentAttributes['placeholder'])) {
+            $attributes['placeholder'] = $this->config['defaultparts']['scheme'] . "://example.com"; //example url
+        }
+
         if ($this->config['html5validation']) {
             $attributes += array(
                 'type' => 'url', //html5 field type
@@ -108,7 +112,7 @@ class ExternalURLField extends TextField
         }
 
         return array_merge(
-            parent::getAttributes(),
+            $parentAttributes,
             $attributes
         );
     }


### PR DESCRIPTION
Currently the module forcefully applies a `{default-scheme}://example.com` placeholder on ExternalURLField.

In some circumstances, it makes sense to allow a placeholder to be set at a per-field instance level. An ExternalURLField that allows an editor to set a Canonical URL for a page, for example, might want to display the existing page's URL as placeholder - rather than https://example.com.

This PR updates the existing ExternalURLField::getAttributes() minimally, just checking for a placeholder attribute value, and only applying the default value if one has not already been supplied. 