### PR TITLE
FIX - setValue method doesn't match FormField

### DIFF
--- a/src/ExternalURLField.php
+++ b/src/ExternalURLField.php
@@ -117,7 +117,7 @@ class ExternalURLField extends TextField
      * Rebuild url on save
      * @param string $url
      */
-    public function setValue($url)
+    public function setValue($url, $data = NULL)
     {
         if ($url) {
             $url = $this->rebuildURL($url);


### PR DESCRIPTION
This fixes the setValue method on the ExternalURLField not matching FormField.

Error:

Warning: Declaration of BurnBright\ExternalURLField\ExternalURLField::setValue($url) should be compatible with SilverStripe\Forms\FormField::setValue($value, $data = NULL) in /srv/app/externalurlfield/src/ExternalURLField.php on line 12