### PR TITLE
Fixed NoWWW() to stop it removing first 'w' of domain

### DIFF
--- a/src/ExternalURL.php
+++ b/src/ExternalURL.php
@@ -50,7 +50,7 @@ class ExternalURL extends DBVarchar
      */
     public function NoWWW()
     {
-        return ltrim($this->value, "www.");
+        return preg_replace('#^www\.(.+\.)#i', '$1', $this->value);
     }
 
     /**


### PR DESCRIPTION
If you had the URL `http://www.work.com/` and fed it to `$URL.Domain.NoWWW` it spat out: `ork.com` instead of `work.com`.

This PR fixes that by using  `preg_replace` instead of `ltrim`.
https://stackoverflow.com/questions/6336281/php-remove-www-from-url-inside-a-string